### PR TITLE
Use ed25519 for certificate signing algorithm

### DIFF
--- a/serverless/signer/sign_cert.go
+++ b/serverless/signer/sign_cert.go
@@ -185,7 +185,7 @@ func (s *KeySigner) signPublicKey(req *SignRequest) (*ssh.Certificate, error) {
 	// extensions
 	setExtensions(cert, req)
 	// use rsa-sha2-256 for sign keys
-	sshAlgorithmSigner, err := newAlgorithmSignerFromSigner(s.ca, ssh.SigAlgoRSASHA2256)
+	sshAlgorithmSigner, err := newAlgorithmSignerFromSigner(s.ca, ssh.KeyAlgoED25519)
 	if err != nil {
 		log.Error().
 			Err(err).


### PR DESCRIPTION
For whatever reason the lambda doesn't work with the rsa-sha2-256
algorithm. We suspect it's an issue with the runtime environment (maybe
the version of OpenSSH provided doesn't support rsa-sha2-256 for some
reason). Switching to ed25519 works and is probably preferable anyway.

Co-authored-by: Vivian Wei <vivian.wei@mycase.com>